### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ lightdm-login-chromiumos
 
 Installs Chromium OS Aura window manager to Ubuntu(64bit only), with embedded Chromium browser(canary snapshot). Binaries are downloaded from http://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html 
 
-###Window mode (run with chromeos from terminal)
+### Window mode (run with chromeos from terminal)
 ![alt text](http://screencloud.net/img/screenshots/671f8285738e0f54abbb29d7749f4efc.png "Windowed mode")
 
-###Standalone mode (select at login screen)
+### Standalone mode (select at login screen)
 ![alt text](http://screencloud.net/img/screenshots/54573dd3fbb263b24e5984263d6fbf68.png "Standalone mode")
 
-##How to install
+## How to install
 
     wget https://dl.dropbox.com/u/302704/chromiumos/lightdm-login-chromiumos_1.1_amd64.deb
     sudo dpkg -i lightdm-login-chromiumos_1.1_amd64.deb
     sudo apt-get -f install
 
-##FAQ
+## FAQ
 
   https://github.com/dz0ny/lightdm-login-chromeos/issues?labels=faq
 
-##What works: 
+## What works: 
  
  - Login directly from LightDM (at login screen)
  - Sync, apps, bookmarks
@@ -31,7 +31,7 @@ Installs Chromium OS Aura window manager to Ubuntu(64bit only), with embedded Ch
  - Tablet mode
  - Boot directly to ChromiumOS
 
-##What doesn't work
+## What doesn't work
 
  - Importing images from camera, other disks etc (missing dbus service, mtp deamon)
  - System controls, data is ignored and replaced with fake data ![alt text](http://screencloud.net/img/screenshots/ad06d7eb8b443e8ad2d650d65ea2d529.png "Fake date")
@@ -39,19 +39,19 @@ Installs Chromium OS Aura window manager to Ubuntu(64bit only), with embedded Ch
  - Special "KIOSK" mode (switch still exists)
  - Auto-updates
 
-##Computability with Ubuntu
+## Computability with Ubuntu
 
   The plan is to port most functionality from ChromeOS (picture import, volume control etc.) BUt in order to do this, someone needs to write d-bus services(this is how chromeos ui communicates with system). Currently I'am writing services for sound(pulseaudio) and networking(networkmanager mashup). 
 
-##Can I build my own version of ChromiumOS browser for Ubuntu?
+## Can I build my own version of ChromiumOS browser for Ubuntu?
 
   YES! Check http://www.chromium.org/developers/how-tos/build-instructions-chromeos
 
-##Interesting stuff
+## Interesting stuff
 
 If you login with `chronos` user you will get full experience, but you won't be able to get through with initial setup. Mainly because bunch of system services are not present. If you start this way you can entirely skip lightdm and start system like it is chromebook. 
 
-##What this *deb does?
+## What this *deb does?
 
 It simply downloads(official Google builds), chromiumos browser with aura WM. Sets `chromeos` command that launches chromiumos aura in windowed mode and for bonus, you can also login directly to chromiumos straight from login screen.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
